### PR TITLE
Fix SubMesh IsGlobal

### DIFF
--- a/packages/dev/core/src/Meshes/subMesh.ts
+++ b/packages/dev/core/src/Meshes/subMesh.ts
@@ -235,7 +235,8 @@ export class SubMesh implements ICullable {
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public get IsGlobal(): boolean {
-        return this.verticesStart === 0 && this.verticesCount === this._mesh.getTotalVertices();
+        return this.verticesStart === 0 && this.verticesCount === this._mesh.getTotalVertices() &&
+            this.indexStart === 0 && this.indexCount === this._mesh.getTotalIndices();
     }
 
     /**


### PR DESCRIPTION
Currently IsGlobal returns true if the subMesh has all the vertices of the mesh but it should check if the subMesh also has all the Indices of the mesh.

Currently the mesh's full bounding info is returned by getBoundingInfo even when the subMesh has all of the vertices but only some of the indices, e.g. as created created by CreateTiledGround, but it should return the subMesh's bounding info, which is much smaller than the whole mesh's.

Forum issue: https://forum.babylonjs.com/t/find-or-define-center-point-of-submesh/30400/3 